### PR TITLE
# 11 - [WARNING] /path/to/SomeType.java found raw type: org.gwtproject.editor.client.adapters.SimpleEditor missing type arguments... - fixed

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -70,7 +70,7 @@ jobs:
           java-version: '11'
           cache: maven
       - name: Test with Maven
-        run: mvn test -ntp
+        run: mvn clean test -ntp
       - uses: actions/upload-artifact@v4
         if: failure()
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -59,9 +59,28 @@ jobs:
       - name: Compile with Maven
         run: mvn compile -ntp
 
-  test-jdk11:
+  check-versions:
     runs-on: ubuntu-latest
     needs: [ build-jdk11, build-jdk17, build-jdk21 ]
+    timeout-minutes: 8
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '11'
+          cache: maven
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: maven
+      - name: Check versions with Maven
+        run: mvn versions:display-dependency-updates -ntp
+
+  test-jdk11:
+    runs-on: ubuntu-latest
+    needs: [ build-jdk11 ]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -70,7 +89,7 @@ jobs:
           java-version: '11'
           cache: maven
       - name: Test with Maven
-        run: mvn clean test -ntp
+        run: mvn test -ntp
       - uses: actions/upload-artifact@v4
         if: failure()
         with:
@@ -78,7 +97,7 @@ jobs:
           path: target/surefire-reports/
   test-jdk17:
     runs-on: ubuntu-latest
-    needs: [ build-jdk11, build-jdk17, build-jdk21 ]
+    needs: [ build-jdk17 ]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -95,7 +114,7 @@ jobs:
           path: target/surefire-reports/
   test-jdk21:
     runs-on: ubuntu-latest
-    needs: [ build-jdk11, build-jdk17, build-jdk21 ]
+    needs: [ build-jdk21 ]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -110,6 +129,7 @@ jobs:
         with:
           name: surefire-report
           path: target/surefire-reports/
+
   owasp:
     runs-on: ubuntu-latest
     timeout-minutes: 8

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,32 +1,130 @@
-#
-# Copyright © 2018 The GWT Project Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
+name: Build & Deploy
 
-name: CI
-
-on: [push, pull_request]
-
+on:
+  push:
+    branches:
+      - dev
+      - main
+    paths-ignore:
+      - "README.md"
 jobs:
-  build:
+  build-jdk11:
     runs-on: ubuntu-latest
-
     steps:
-      - uses: actions/checkout@v2
-
-      # TODO: cache dependencies (taking into accounts: Maven plugins, snapshots, etc.)
-
-      - name: Build with Maven
-        run: JAVA_HOME=$JAVA_HOME_8_X64 mvn -V -B -ntp -U -e verify
-
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '11'
+          cache: maven
+      - name: Compile with Maven
+        run: mvn compile -ntp
+  build-jdk17:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: maven
+      - name: Compile with Maven
+        run: mvn compile -ntp
+  build-jdk21:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+      - name: Compile with Maven
+        run: mvn compile -ntp
+  test-jdk11:
+    runs-on: ubuntu-latest
+    needs: [ build-jdk11, build-jdk17, build-jdk21 ]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '11'
+          cache: maven
+      - name: Test with Maven
+        run: mvn test -ntp
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: surefire-report
+          path: target/surefire-reports/
+  test-jdk17:
+    runs-on: ubuntu-latest
+    needs: [ build-jdk11, build-jdk17, build-jdk21 ]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: maven
+      - name: Test with Maven
+        run: mvn test -ntp
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: surefire-report
+          path: target/surefire-reports/
+  test-jdk21:
+    runs-on: ubuntu-latest
+    needs: [ build-jdk11, build-jdk17, build-jdk21 ]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+      - name: Test with Maven
+        run: mvn test -ntp
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: surefire-report
+          path: target/surefire-reports/
+  owasp:
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    needs: [ build-jdk11, build-jdk17, build-jdk21 ]
+    services:
+      owasp-db:
+        image: nalusolutionsgmbh/owasp-maven-action:latest
+        options: --entrypoint /bin/sh --name owasp-db --hostname owasp-db
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '11'
+          cache: maven
+      - name: Copy owasp database from container to runner
+        run: docker cp $(docker ps -aqf "name=owasp-db"):/dependency-check/data ./dependency-checker-db/
+      - name: OWASP Check
+        run: |
+          mvn org.owasp:dependency-check-maven:aggregate \
+          -DdataDirectory=./dependency-checker-db \
+          -DfailBuildOnCVSS=7 \
+          -Dodc.outputDirectory=reports \
+          -Dformat=HTML \
+          -DautoUpdate=false \
+          -DsuppressionFiles=./owasp/owasp-suppressions.xml
+      - name: Upload OWASP results
+        if: always()
+        uses: actions/upload-artifact@master
+        with:
+          name: OWASP report
+          path: ${{github.workspace}}/**/reports/dependency-check-report.html

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,8 +22,8 @@ on:
       - dev
       - main
       - issue/11
-    paths-ignore:
-      - "README.md"
+#    paths-ignore:
+#      - "README.md"
 jobs:
   build-jdk11:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,3 +1,19 @@
+#
+# Copyright © 2018 The GWT Project Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 name: Build & Deploy
 
 on:
@@ -42,6 +58,7 @@ jobs:
           cache: maven
       - name: Compile with Maven
         run: mvn compile -ntp
+
   test-jdk11:
     runs-on: ubuntu-latest
     needs: [ build-jdk11, build-jdk17, build-jdk21 ]

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - dev
       - main
+      - issue/11
     paths-ignore:
       - "README.md"
 jobs:

--- a/README.md
+++ b/README.md
@@ -181,13 +181,12 @@ public class PersonComponent implements IsElement<HTMLDivElement>, Editor<Person
 
 ```java
 PersonComponent personComponent = new PersonComponent();
-
         Person person = new Person(10, "Ahmad", false);
-
-        DomGlobal.document.body.appendChild(Card.create()
-                .appendChild(personComponent)
-                .asElement());
-
+        DomGlobal.document
+                 .body
+                 .appendChild(Card.create()
+                                  .appendChild(personComponent)
+                                  .asElement());
         personComponent.edit(person);
         
 ```

--- a/gwt-editor-gwt2-tests/pom.xml
+++ b/gwt-editor-gwt2-tests/pom.xml
@@ -18,7 +18,7 @@
     <properties>
         <maven.gwt.plugin>1.0.0</maven.gwt.plugin>
 
-        <gwt.version>2.9.0</gwt.version>
+        <gwt.version>2.10.0</gwt.version>
         <junit.version>4.13.1</junit.version>
     </properties>
 

--- a/gwt-editor-gwt2-tests/pom.xml
+++ b/gwt-editor-gwt2-tests/pom.xml
@@ -16,21 +16,21 @@
     <description>Test cases for the GWT 2 tests</description>
 
     <properties>
-        <maven.gwt.plugin>1.0.0</maven.gwt.plugin>
+        <maven.gwt.plugin>1.1.0</maven.gwt.plugin>
 
-        <gwt.version>2.10.0</gwt.version>
+        <gwt.version>2.11.0</gwt.version>
         <junit.version>4.13.1</junit.version>
     </properties>
 
     <dependencies>
         <dependency>
-            <groupId>com.google.gwt</groupId>
+            <groupId>org.gwtproject</groupId>
             <artifactId>gwt-user</artifactId>
             <version>${gwt.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.google.gwt</groupId>
+            <groupId>org.gwtproject</groupId>
             <artifactId>gwt-dev</artifactId>
             <version>${gwt.version}</version>
             <scope>test</scope>

--- a/gwt-editor-gwt2-tests/pom.xml
+++ b/gwt-editor-gwt2-tests/pom.xml
@@ -18,7 +18,7 @@
     <properties>
         <maven.gwt.plugin>1.1.0</maven.gwt.plugin>
 
-        <gwt.version>2.11.0</gwt.version>
+        <gwt.version>2.12.2</gwt.version>
         <junit.version>4.13.1</junit.version>
     </properties>
 

--- a/gwt-editor-j2cl-tests/pom.xml
+++ b/gwt-editor-j2cl-tests/pom.xml
@@ -16,12 +16,8 @@
   <url>https://github.com/gwtproject/gwt-editor</url>
 
   <properties>
-    <maven.j2cl.plugin>0.16-SNAPSHOT</maven.j2cl.plugin>
-
-    <!-- CI -->
-    <vertispan.j2cl.repo.url>https://repo.vertispan.com/j2cl/</vertispan.j2cl.repo.url>
-
-    <j2cl.version>0.8-SNAPSHOT</j2cl.version>
+    <maven.j2cl.plugin>0.22.0</maven.j2cl.plugin>
+    <j2cl.version>0.11.0-9336533b6</j2cl.version>
   </properties>
 
   <dependencies>
@@ -74,8 +70,7 @@
             <goals>
               <goal>test</goal>
             </goals>
-<!-- TODO does not work. See https://github.com/Vertispan/j2clmavenplugin/issues/14 for more informations -->
-<!--            <phase>test</phase>-->
+            <phase>test</phase>
             <configuration>
               <defines>
                 <gwt.enableDebugId>true</gwt.enableDebugId>
@@ -111,20 +106,4 @@
       </plugin>
     </plugins>
   </build>
-
-  <repositories>
-    <repository>
-      <id>${vertispan.j2cl.repo.id}</id>
-      <name>${vertispan.j2cl.repo.name}</name>
-      <url>${vertispan.j2cl.repo.url}</url>
-    </repository>
-  </repositories>
-
-  <pluginRepositories>
-    <pluginRepository>
-      <id>vertispan-releases</id>
-      <name>Vertispan hosted artifacts-releases</name>
-      <url>${vertispan.j2cl.repo.url}</url>
-    </pluginRepository>
-  </pluginRepositories>
 </project>

--- a/gwt-editor-j2cl-tests/src/test/java/org/gwtproject/validation/client/impl/ConstraintViolationImpl.java
+++ b/gwt-editor-j2cl-tests/src/test/java/org/gwtproject/validation/client/impl/ConstraintViolationImpl.java
@@ -65,7 +65,7 @@ public final class ConstraintViolationImpl<T> implements ConstraintViolation<T>,
     } else if (!(o instanceof ConstraintViolationImpl)) {
       return false;
     } else {
-      ConstraintViolationImpl<?> other = (ConstraintViolationImpl) o;
+      ConstraintViolationImpl<?> other = (ConstraintViolationImpl<?>) o;
       return Objects.equals(this.message, other.message)
           && Objects.equals(this.propertyPath, other.propertyPath)
           && Objects.equals(this.rootBean, other.rootBean)

--- a/gwt-editor-processor/pom.xml
+++ b/gwt-editor-processor/pom.xml
@@ -179,7 +179,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>${plugin.version.surfire}</version>
+                <version>${maven.surfire.plugin}</version>
                 <executions>
                     <execution>
                         <id>unit-tests</id>

--- a/gwt-editor-processor/pom.xml
+++ b/gwt-editor-processor/pom.xml
@@ -46,8 +46,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
 
         <auto.common.version>1.1</auto.common.version>
         <auto.service.version>1.0</auto.service.version>

--- a/gwt-editor-processor/pom.xml
+++ b/gwt-editor-processor/pom.xml
@@ -179,7 +179,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.21.0</version>
+                <version>${plugin.version.surfire}</version>
                 <executions>
                     <execution>
                         <id>unit-tests</id>
@@ -190,6 +190,7 @@
                     </execution>
                 </executions>
                 <configuration>
+                    <argLine>${test.jvm.flags}</argLine>
                     <includes>
                         <include>**/Test*.java</include>
                         <include>**/*Test.java</include>
@@ -321,6 +322,19 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+        <profile>
+            <id>add-exports</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <properties>
+                <test.jvm.flags>
+                    --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+                    --add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED
+                    --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+                </test.jvm.flags>
+            </properties>
         </profile>
     </profiles>
 </project>

--- a/gwt-editor-processor/pom.xml
+++ b/gwt-editor-processor/pom.xml
@@ -52,12 +52,12 @@
         <auto.common.version>1.1</auto.common.version>
         <auto.service.version>1.0</auto.service.version>
         <compile-testing.version>0.18</compile-testing.version>
-        <gwt.version>2.9.0</gwt.version>
-        <javapoet.version>1.12.1</javapoet.version>
+        <gwt.version>2.12.2</gwt.version>
+        <javapoet.version>1.13.0</javapoet.version>
         <compile.testing.version>0.18</compile.testing.version>
         <junit.version>4.13.1</junit.version>
         <org.truth.version>0.23</org.truth.version>
-        <truth.version>1.0</truth.version>
+        <truth.version>1.4.4</truth.version>
 
         <maven.shade.plugin>3.2.4</maven.shade.plugin>
     </properties>
@@ -93,13 +93,13 @@
 
         <!-- only for testing -->
         <dependency>
-            <groupId>com.google.gwt</groupId>
+            <groupId>org.gwtproject</groupId>
             <artifactId>gwt-user</artifactId>
             <version>${gwt.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.google.gwt</groupId>
+            <groupId>org.gwtproject</groupId>
             <artifactId>gwt-dev</artifactId>
             <version>${gwt.version}</version>
             <scope>test</scope>

--- a/gwt-editor-processor/src/main/java/org/gwtproject/editor/processor/model/EditorModel.java
+++ b/gwt-editor-processor/src/main/java/org/gwtproject/editor/processor/model/EditorModel.java
@@ -111,7 +111,7 @@ public class EditorModel {
         TypeMirror fieldClassType = field.asType();
         if (shouldExamine(fieldClassType)) {
           List<EditorProperty> data =
-              new EditorProperty.Builder(editorTypes, dataType)
+              new EditorProperty.Builder(editorTypes, dataType, editorType)
                   .access(field)
                   .build(Optional.ofNullable(editorSoFar));
           accumulateEditorData(data, flatData, toReturn);
@@ -145,7 +145,7 @@ public class EditorModel {
           }
 
           List<EditorProperty> data =
-              new EditorProperty.Builder(editorTypes, dataType)
+              new EditorProperty.Builder(editorTypes, dataType, editorType)
                   .access(method)
                   .build(Optional.ofNullable(editorSoFar));
           accumulateEditorData(data, flatData, toReturn);
@@ -162,7 +162,7 @@ public class EditorModel {
               .get(2);
 
       EditorProperty subEditor =
-          new EditorProperty.Builder(editorTypes, dataType)
+          new EditorProperty.Builder(editorTypes, dataType, editorType)
               .root(subEditorType)
               .build(Optional.ofNullable(editorSoFar))
               .get(0); // doesn't matter which instance, there must be at least one
@@ -266,7 +266,7 @@ public class EditorModel {
   }
 
   public EditorProperty getRootData() {
-    return new EditorProperty.Builder(editorTypes, dataType)
+    return new EditorProperty.Builder(editorTypes, dataType, editorType)
         .root(getEditorType())
         .build(Optional.empty())
         .get(0);

--- a/gwt-editor-processor/src/main/java/org/gwtproject/editor/processor/model/EditorProperty.java
+++ b/gwt-editor-processor/src/main/java/org/gwtproject/editor/processor/model/EditorProperty.java
@@ -17,6 +17,7 @@ package org.gwtproject.editor.processor.model;
 
 import com.google.auto.common.MoreElements;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.regex.Pattern;
@@ -43,10 +44,12 @@ public class EditorProperty {
 
     private Stream.Builder<EditorProperty> builder = Stream.builder();
     private Stream<EditorProperty> stream;
+    private TypeMirror editorType;
 
-    public Builder(EditorTypes types, TypeMirror dataType) {
+    public Builder(EditorTypes types, TypeMirror dataType, TypeMirror editorType) {
       this.types = types;
       this.dataType = dataType;
+      this.editorType = editorType;
     }
 
     public Builder root(TypeMirror type) {
@@ -237,8 +240,16 @@ public class EditorProperty {
         if (!foundGetterForPart) {
           //        poison(noGetterMessage(path, proxyType));
           //          return;
-          throw new IllegalStateException(
-              "generation aborted! No getter exists for >>" + path + "<<");
+          String message =
+              "gwt-editor ==> generation aborted! No getter exists for >>"
+                  + path
+                  + "<< of owner >>"
+                  + owner.toString()
+                  + "<<";
+          if (Objects.nonNull(this.editorType)) {
+            message += " in editor >>" + this.editorType + "<<";
+          }
+          throw new IllegalStateException(message);
         }
       }
 
@@ -308,7 +319,7 @@ public class EditorProperty {
                                 property.editorType)
                             .get(2);
                     property.composedData =
-                        new Builder(types, dataType)
+                        new Builder(types, dataType, editorType)
                             .root(subEditorType)
                             .build(Optional.of(property))
                             .get(0);

--- a/gwt-editor-processor/src/test/java/org/gwtproject/editor/client/SimpleBeanEditorTest.java
+++ b/gwt-editor-processor/src/test/java/org/gwtproject/editor/client/SimpleBeanEditorTest.java
@@ -28,8 +28,9 @@ import org.gwtproject.editor.client.annotation.IsDriver;
  * AbstractEditorDriverGenerator.
  */
 public class SimpleBeanEditorTest extends TestCase {
-  class AddressCoEditorView extends LeafAddressEditor implements IsEditor<LeafAddressEditor> {
-    private LeafAddressEditor addressEditor = new LeafAddressEditor();
+  static class AddressCoEditorView extends LeafAddressEditor
+      implements IsEditor<LeafAddressEditor> {
+    private final LeafAddressEditor addressEditor = new LeafAddressEditor();
 
     @Override
     public LeafAddressEditor asEditor() {
@@ -131,7 +132,7 @@ public class SimpleBeanEditorTest extends TestCase {
   interface PersonEditorWithAddressEditorViewDriver
       extends SimpleBeanEditorDriver<Person, PersonEditorWithAddressEditorView> {}
 
-  class SampleView implements Editor<Sample> {
+  static class SampleView implements Editor<Sample> {
     SimpleEditor<Integer> id = SimpleEditor.of(0);
   }
 
@@ -151,7 +152,7 @@ public class SimpleBeanEditorTest extends TestCase {
   interface PersonEditorWithAliasedSubEditorsDriver
       extends SimpleBeanEditorDriver<Person, PersonEditorWithAliasedSubEditors> {}
 
-  class PersonEditorWithCoAddressEditorView implements Editor<Person> {
+  static class PersonEditorWithCoAddressEditorView implements Editor<Person> {
     AddressCoEditorView addressEditor = new AddressCoEditorView();
     SimpleEditor<String> name = SimpleEditor.of(UNINITIALIZED);
   }
@@ -221,7 +222,7 @@ public class SimpleBeanEditorTest extends TestCase {
     }
   }
 
-  class PersonEditorWithValueAwareAddressEditor implements Editor<Person> {
+  static class PersonEditorWithValueAwareAddressEditor implements Editor<Person> {
     ValueAwareAddressEditor addressEditor = new ValueAwareAddressEditor();
     SimpleEditor<String> name = SimpleEditor.of(UNINITIALIZED);
 
@@ -233,7 +234,7 @@ public class SimpleBeanEditorTest extends TestCase {
   interface PersonEditorWithValueAwareAddressEditorDriver
       extends SimpleBeanEditorDriver<Person, PersonEditorWithValueAwareAddressEditor> {}
 
-  class PersonEditorWithValueAwareLeafAddressEditor implements Editor<Person> {
+  static class PersonEditorWithValueAwareLeafAddressEditor implements Editor<Person> {
     ValueAwareLeafAddressEditor addressEditor = new ValueAwareLeafAddressEditor();
     SimpleEditor<String> name = SimpleEditor.of(UNINITIALIZED);
 
@@ -249,7 +250,7 @@ public class SimpleBeanEditorTest extends TestCase {
     SimpleEditor<String> name = SimpleEditor.of(UNINITIALIZED);
   }
 
-  class PersonWithList {
+  static class PersonWithList {
     String name = "PersonWithList";
     List<Address> addresses = new ArrayList<Address>();
 
@@ -262,7 +263,7 @@ public class SimpleBeanEditorTest extends TestCase {
     }
   }
 
-  class PersonWithListEditor implements Editor<PersonWithList> {
+  static class PersonWithListEditor implements Editor<PersonWithList> {
     SimpleEditor<String> nameEditor = SimpleEditor.of(UNINITIALIZED);
     ListEditor<Address, ValueAwareAddressEditor> addressesEditor =
         ListEditor.of(
@@ -320,7 +321,8 @@ public class SimpleBeanEditorTest extends TestCase {
   }
 
   /** All the mix-ins. Not that this seems like a good idea... */
-  class ValueAwareLeafAddressEditor extends LeafAddressEditor implements ValueAwareEditor<Address> {
+  static class ValueAwareLeafAddressEditor extends LeafAddressEditor
+      implements ValueAwareEditor<Address> {
     int flushCalled;
     int setDelegateCalled;
 
@@ -338,7 +340,7 @@ public class SimpleBeanEditorTest extends TestCase {
     }
   }
 
-  class TaggedItemAddressEditor implements Editor<TaggedItem<Address>> {
+  static class TaggedItemAddressEditor implements Editor<TaggedItem<Address>> {
     @Path("item.city")
     SimpleEditor<String> itemCityEditor = SimpleEditor.of(UNINITIALIZED);
 
@@ -575,8 +577,9 @@ public class SimpleBeanEditorTest extends TestCase {
   public void testListEditor() {
     final SortedMap<Integer, SimpleEditor<String>> positionMap =
         new TreeMap<Integer, SimpleEditor<String>>();
-    @SuppressWarnings("unchecked")
-    final SimpleEditor<String>[] disposed = new SimpleEditor[1];
+    //    final SimpleEditor<String>[] disposed = new SimpleEditor[1];
+    final List<SimpleEditor<String>> disposed = new ArrayList<>();
+    disposed.add(null);
     class StringSource extends EditorSource<SimpleEditor<String>> {
       @Override
       public SimpleEditor<String> create(int index) {
@@ -587,7 +590,7 @@ public class SimpleBeanEditorTest extends TestCase {
 
       @Override
       public void dispose(SimpleEditor<String> editor) {
-        disposed[0] = editor;
+        disposed.set(0, editor);
         positionMap.values().remove(editor);
       }
 
@@ -636,7 +639,7 @@ public class SimpleBeanEditorTest extends TestCase {
     // Delete an element
     SimpleEditor<String> expectedDisposed = editors.get(0);
     mutableList.remove(0);
-    assertSame(expectedDisposed, disposed[0]);
+    assertSame(expectedDisposed, disposed.get(0));
     assertEquals(3, editors.size());
     assertEquals("quux", editors.get(2).getValue());
     assertEquals(editors, new ArrayList<>(positionMap.values()));
@@ -654,9 +657,8 @@ public class SimpleBeanEditorTest extends TestCase {
     assertEquals(editors, new ArrayList<>(positionMap.values()));
 
     // Edit again: should reuse sub-editors and dispose unneeded ones
-    disposed[0] = null;
+    disposed.set(0, null);
     expectedDisposed = editors.get(2);
-    @SuppressWarnings("unchecked")
     List<SimpleEditor<String>> expectedEditors = Arrays.asList(editors.get(0), editors.get(1));
     driver.edit(rawData);
     assertEquals(expectedEditors, editors);
@@ -665,7 +667,7 @@ public class SimpleBeanEditorTest extends TestCase {
     assertEquals(rawData.size(), editors.size());
     assertEquals(rawData, Arrays.asList(editors.get(0).getValue(), editors.get(1).getValue()));
     assertEquals(editors, new ArrayList<SimpleEditor<String>>(positionMap.values()));
-    assertEquals(expectedDisposed, disposed[0]);
+    assertEquals(expectedDisposed, disposed.get(0));
   }
 
   /** Ensure that a ListEditor deeper in the chain is properly flushed. */

--- a/gwt-editor-processor/src/test/java/org/gwtproject/editor/processor/model/EditorModelTest.java
+++ b/gwt-editor-processor/src/test/java/org/gwtproject/editor/processor/model/EditorModelTest.java
@@ -23,7 +23,6 @@ import com.google.web.bindery.requestfactory.shared.EntityProxy;
 import com.google.web.bindery.requestfactory.shared.RequestFactory;
 import java.util.Arrays;
 import java.util.List;
-import javax.lang.model.element.Element;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
@@ -360,10 +359,10 @@ public class EditorModelTest {
     checkPersonReadonly(fields.get(1));
   }
 
-  /**
-   * Tests the case where an Editor wants to editor a property that is not provided by its
-   * associated Proxy type.
-   */
+  //  /**
+  //   * Tests the case where an Editor wants to editor a property that is not provided by its
+  //   * associated Proxy type.
+  //   */
   //  public void testMissingGetter() {
   //    UnitTestTreeLogger.Builder builder = new UnitTestTreeLogger.Builder();
   //    builder.setLowestLogLevel(TreeLogger.ERROR);
@@ -384,7 +383,7 @@ public class EditorModelTest {
   //    testLogger.assertCorrectLogEntries();
   //  }
 
-  /** Tests the sanity-check error messages emitted by the constructor. */
+  //  /** Tests the sanity-check error messages emitted by the constructor. */
   //  public void testSanityErrorMessages() {
   //    UnitTestTreeLogger.Builder builder = new UnitTestTreeLogger.Builder();
   //    builder.setLowestLogLevel(TreeLogger.ERROR);
@@ -498,7 +497,7 @@ public class EditorModelTest {
     Assert.assertEquals("setName", editorField.getSetterName());
   }
 
-  /** @param editorField */
+  /** @param editorField editor property */
   private void checkPersonReadonly(EditorProperty editorField) {
     assertNotNull(editorField);
     assertEquals(typeMirrorFor(SimpleEditor.class), raw(editorField.getEditorType()));
@@ -515,9 +514,9 @@ public class EditorModelTest {
         MoreTypes.equivalence().equivalent(expected, actual));
   }
 
-  private Element typeElementFor(Class<?> clazz) {
-    return MoreTypes.asElement(raw(elements.getTypeElement(clazz.getCanonicalName()).asType()));
-  }
+  //  private Element typeElementFor(Class<?> clazz) {
+  //    return MoreTypes.asElement(raw(elements.getTypeElement(clazz.getCanonicalName()).asType()));
+  //  }
 
   private TypeMirror typeMirrorFor(Class<?> clazz) {
     return raw(elements.getTypeElement(clazz.getCanonicalName()).asType());
@@ -683,7 +682,7 @@ public class EditorModelTest {
     SimpleEditor<Long> lastModified;
     public SimpleEditor<String> name;
     SimpleEditor<String> readonly;
-    public static SimpleEditor ignoredStatic;
+    public static SimpleEditor<String> ignoredStatic;
     private SimpleEditor<String> ignoredPrivate;
     @Editor.Ignore public SimpleEditor<String> ignoredPublic;
   }
@@ -740,7 +739,7 @@ public class EditorModelTest {
     interface AProxy extends EntityProxy {}
 
     interface AEditor extends Editor<AProxy> {
-      SimpleEditor needsParameterization();
+      SimpleEditor<AProxy> needsParameterization();
     }
   }
 

--- a/gwt-editor-processor/src/test/resources/org/gwtproject/editor/processor/test01/result/TestEditor01_Driver_Impl.java
+++ b/gwt-editor-processor/src/test/resources/org/gwtproject/editor/processor/test01/result/TestEditor01_Driver_Impl.java
@@ -1,6 +1,7 @@
 package org.gwtproject.editor.processor.test01;
 
 import java.lang.Override;
+import java.lang.SuppressWarnings;
 import org.gwtproject.editor.client.EditorVisitor;
 import org.gwtproject.editor.client.impl.AbstractSimpleBeanEditorDriver;
 import org.gwtproject.editor.client.impl.RootEditorContext;
@@ -9,6 +10,7 @@ import org.gwtproject.editor.processor.common.EditorBean;
 
 public class TestEditor01_Driver_Impl extends AbstractSimpleBeanEditorDriver<EditorBean, TestEditor01> implements TestEditor01.Driver {
   @Override
+  @SuppressWarnings("unchecked")
   public void accept(EditorVisitor visitor) {
     RootEditorContext<EditorBean> ctx = new RootEditorContext<EditorBean>(getDelegate(), (Class<EditorBean>)(Class)org.gwtproject.editor.processor.common.EditorBean.class, getObject());
     ctx.traverse(visitor, getDelegate());

--- a/gwt-editor-processor/src/test/resources/org/gwtproject/editor/processor/test01/result/TestEditor01_id_Context.java
+++ b/gwt-editor-processor/src/test/resources/org/gwtproject/editor/processor/test01/result/TestEditor01_id_Context.java
@@ -1,41 +1,36 @@
 package org.gwtproject.editor.processor.test01;
-
 import java.lang.Class;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
+import java.lang.SuppressWarnings;
 import org.gwtproject.editor.client.Editor;
 import org.gwtproject.editor.client.impl.AbstractEditorContext;
 import org.gwtproject.editor.processor.common.EditorBean;
-
 public class TestEditor01_id_Context extends AbstractEditorContext<String> {
   private final EditorBean parent;
-  
   public TestEditor01_id_Context(EditorBean parent, Editor<String> editor, String path) {
     super(editor, path);
     this.parent = parent;
   }
-  
   @Override
   public boolean canSetInModel() {
     return parent != null && true && true;
   }
-  
   @Override
+  @SuppressWarnings("unchecked")
   public String checkAssignment(Object value) {
     return (String) value;
   }
-  
   @Override
-  public Class getEditedType() {
+  @SuppressWarnings("unchecked")
+  public Class<String> getEditedType() {
     return java.lang.String.class;
   }
-  
   @Override
   public String getFromModel() {
     return (parent != null && true) ? parent.getId() : null;
   }
-  
   @Override
   public void setInModel(String data) {
     parent.setId(data);

--- a/gwt-editor-processor/src/test/resources/org/gwtproject/editor/processor/test02/result/TestEditor02_Driver_Impl.java
+++ b/gwt-editor-processor/src/test/resources/org/gwtproject/editor/processor/test02/result/TestEditor02_Driver_Impl.java
@@ -1,6 +1,7 @@
 package org.gwtproject.editor.processor.test02;
 
 import java.lang.Override;
+import java.lang.SuppressWarnings;
 import org.gwtproject.editor.client.EditorVisitor;
 import org.gwtproject.editor.client.impl.AbstractSimpleBeanEditorDriver;
 import org.gwtproject.editor.client.impl.RootEditorContext;
@@ -9,6 +10,7 @@ import org.gwtproject.editor.processor.common.EditorBeanWithInterface;
 
 public class TestEditor02_Driver_Impl extends AbstractSimpleBeanEditorDriver<EditorBeanWithInterface, TestEditor02> implements TestEditor02.Driver {
   @Override
+  @SuppressWarnings("unchecked")
   public void accept(EditorVisitor visitor) {
     RootEditorContext<EditorBeanWithInterface> ctx = new RootEditorContext<EditorBeanWithInterface>(getDelegate(), (Class<EditorBeanWithInterface>)(Class)org.gwtproject.editor.processor.common.EditorBeanWithInterface.class, getObject());
     ctx.traverse(visitor, getDelegate());

--- a/gwt-editor-processor/src/test/resources/org/gwtproject/editor/processor/test02/result/TestEditor02_id_Context.java
+++ b/gwt-editor-processor/src/test/resources/org/gwtproject/editor/processor/test02/result/TestEditor02_id_Context.java
@@ -1,42 +1,37 @@
 package org.gwtproject.editor.processor.test02;
-
 import java.lang.Class;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
+import java.lang.SuppressWarnings;
 import org.gwtproject.editor.client.Editor;
 import org.gwtproject.editor.client.impl.AbstractEditorContext;
 import org.gwtproject.editor.processor.common.EditorBeanWithInterface;
-
 public class TestEditor02_id_Context extends AbstractEditorContext<String> {
   private final EditorBeanWithInterface parent;
-  
   public TestEditor02_id_Context(EditorBeanWithInterface parent, Editor<String> editor,
                                  String path) {
     super(editor, path);
     this.parent = parent;
   }
-  
   @Override
   public boolean canSetInModel() {
     return parent != null && true && true;
   }
-  
   @Override
+  @SuppressWarnings("unchecked")
   public String checkAssignment(Object value) {
     return (String) value;
   }
-  
   @Override
-  public Class getEditedType() {
+  @SuppressWarnings("unchecked")
+  public Class<String> getEditedType() {
     return java.lang.String.class;
   }
-  
   @Override
   public String getFromModel() {
     return (parent != null && true) ? parent.getId() : null;
   }
-  
   @Override
   public void setInModel(String data) {
     parent.setId(data);

--- a/gwt-editor-processor/src/test/resources/org/gwtproject/editor/processor/test03/result/TestEditor03_Driver_Impl.java
+++ b/gwt-editor-processor/src/test/resources/org/gwtproject/editor/processor/test03/result/TestEditor03_Driver_Impl.java
@@ -1,6 +1,7 @@
 package org.gwtproject.editor.processor.test03;
 
 import java.lang.Override;
+import java.lang.SuppressWarnings;
 import org.gwtproject.editor.client.EditorVisitor;
 import org.gwtproject.editor.client.impl.AbstractSimpleBeanEditorDriver;
 import org.gwtproject.editor.client.impl.RootEditorContext;
@@ -9,6 +10,7 @@ import org.gwtproject.editor.processor.common.EditorBeanWithInterface;
 
 public class TestEditor03_Driver_Impl extends AbstractSimpleBeanEditorDriver<EditorBeanWithInterface, TestEditor03> implements TestEditor03.Driver {
   @Override
+  @SuppressWarnings("unchecked")
   public void accept(EditorVisitor visitor) {
     RootEditorContext<EditorBeanWithInterface> ctx = new RootEditorContext<EditorBeanWithInterface>(getDelegate(), (Class<EditorBeanWithInterface>)(Class)org.gwtproject.editor.processor.common.EditorBeanWithInterface.class, getObject());
     ctx.traverse(visitor, getDelegate());

--- a/gwt-editor-processor/src/test/resources/org/gwtproject/editor/processor/test03/result/TestEditor03_id_Context.java
+++ b/gwt-editor-processor/src/test/resources/org/gwtproject/editor/processor/test03/result/TestEditor03_id_Context.java
@@ -1,42 +1,37 @@
 package org.gwtproject.editor.processor.test03;
-
 import java.lang.Class;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
+import java.lang.SuppressWarnings;
 import org.gwtproject.editor.client.Editor;
 import org.gwtproject.editor.client.impl.AbstractEditorContext;
 import org.gwtproject.editor.processor.common.EditorBeanWithInterface;
-
 public class TestEditor03_id_Context extends AbstractEditorContext<String> {
   private final EditorBeanWithInterface parent;
-  
   public TestEditor03_id_Context(EditorBeanWithInterface parent, Editor<String> editor,
                                  String path) {
     super(editor, path);
     this.parent = parent;
   }
-  
   @Override
   public boolean canSetInModel() {
     return parent != null && true && true;
   }
-  
   @Override
+  @SuppressWarnings("unchecked")
   public String checkAssignment(Object value) {
     return (String) value;
   }
-  
   @Override
-  public Class getEditedType() {
+  @SuppressWarnings("unchecked")
+  public Class<String> getEditedType() {
     return java.lang.String.class;
   }
-  
   @Override
   public String getFromModel() {
     return (parent != null && true) ? parent.getId() : null;
   }
-  
   @Override
   public void setInModel(String data) {
     parent.setId(data);

--- a/gwt-editor-processor/src/test/resources/org/gwtproject/editor/processor/test04/result/TestEditor04_Driver_Impl.java
+++ b/gwt-editor-processor/src/test/resources/org/gwtproject/editor/processor/test04/result/TestEditor04_Driver_Impl.java
@@ -1,6 +1,7 @@
 package org.gwtproject.editor.processor.test04;
 
 import java.lang.Override;
+import java.lang.SuppressWarnings;
 import org.gwtproject.editor.client.EditorVisitor;
 import org.gwtproject.editor.client.impl.AbstractSimpleBeanEditorDriver;
 import org.gwtproject.editor.client.impl.RootEditorContext;
@@ -9,6 +10,7 @@ import org.gwtproject.editor.processor.common.UserDto;
 
 public class TestEditor04_Driver_Impl extends AbstractSimpleBeanEditorDriver<UserDto, TestEditor04> implements TestEditor04.Driver {
   @Override
+  @SuppressWarnings("unchecked")
   public void accept(EditorVisitor visitor) {
     RootEditorContext<UserDto> ctx = new RootEditorContext<UserDto>(getDelegate(), (Class<UserDto>)(Class)org.gwtproject.editor.processor.common.UserDto.class, getObject());
     ctx.traverse(visitor, getDelegate());

--- a/gwt-editor-processor/src/test/resources/org/gwtproject/editor/processor/test04/result/TestEditor04_active_Context.java
+++ b/gwt-editor-processor/src/test/resources/org/gwtproject/editor/processor/test04/result/TestEditor04_active_Context.java
@@ -1,42 +1,37 @@
 package org.gwtproject.editor.processor.test04;
-
 import java.lang.Boolean;
 import java.lang.Class;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
+import java.lang.SuppressWarnings;
 import org.gwtproject.editor.client.Editor;
 import org.gwtproject.editor.client.impl.AbstractEditorContext;
 import org.gwtproject.editor.processor.common.UserDto;
-
 public class TestEditor04_active_Context extends AbstractEditorContext<Boolean> {
   private final UserDto parent;
-  
   public TestEditor04_active_Context(UserDto parent, Editor<Boolean> editor, String path) {
     super(editor, path);
     this.parent = parent;
   }
-  
   @Override
   public boolean canSetInModel() {
     return parent != null && true && true;
   }
-  
   @Override
+  @SuppressWarnings("unchecked")
   public Boolean checkAssignment(Object value) {
     return (Boolean) value;
   }
-  
   @Override
-  public Class getEditedType() {
+  @SuppressWarnings("unchecked")
+  public Class<Boolean> getEditedType() {
     return java.lang.Boolean.class;
   }
-  
   @Override
   public Boolean getFromModel() {
     return (parent != null && true) ? parent.isActive() : null;
   }
-  
   @Override
   public void setInModel(Boolean data) {
     parent.setActive(data);

--- a/gwt-editor-processor/src/test/resources/org/gwtproject/editor/processor/test04/result/TestEditor04_age_Context.java
+++ b/gwt-editor-processor/src/test/resources/org/gwtproject/editor/processor/test04/result/TestEditor04_age_Context.java
@@ -1,42 +1,37 @@
 package org.gwtproject.editor.processor.test04;
-
 import java.lang.Class;
 import java.lang.Integer;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
+import java.lang.SuppressWarnings;
 import org.gwtproject.editor.client.Editor;
 import org.gwtproject.editor.client.impl.AbstractEditorContext;
 import org.gwtproject.editor.processor.common.UserDto;
-
 public class TestEditor04_age_Context extends AbstractEditorContext<Integer> {
   private final UserDto parent;
-  
   public TestEditor04_age_Context(UserDto parent, Editor<Integer> editor, String path) {
     super(editor, path);
     this.parent = parent;
   }
-  
   @Override
   public boolean canSetInModel() {
     return parent != null && true && true;
   }
-  
   @Override
+  @SuppressWarnings("unchecked")
   public Integer checkAssignment(Object value) {
     return (Integer) value;
   }
-  
   @Override
-  public Class getEditedType() {
+  @SuppressWarnings("unchecked")
+  public Class<Integer> getEditedType() {
     return java.lang.Integer.class;
   }
-  
   @Override
   public Integer getFromModel() {
     return (parent != null && true) ? parent.getAge() : null;
   }
-  
   @Override
   public void setInModel(Integer data) {
     parent.setAge(data);

--- a/gwt-editor-processor/src/test/resources/org/gwtproject/editor/processor/test04/result/TestEditor04_email_Context.java
+++ b/gwt-editor-processor/src/test/resources/org/gwtproject/editor/processor/test04/result/TestEditor04_email_Context.java
@@ -1,41 +1,36 @@
 package org.gwtproject.editor.processor.test04;
-
 import java.lang.Class;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
+import java.lang.SuppressWarnings;
 import org.gwtproject.editor.client.Editor;
 import org.gwtproject.editor.client.impl.AbstractEditorContext;
 import org.gwtproject.editor.processor.common.UserDto;
-
 public class TestEditor04_email_Context extends AbstractEditorContext<String> {
   private final UserDto parent;
-  
   public TestEditor04_email_Context(UserDto parent, Editor<String> editor, String path) {
     super(editor, path);
     this.parent = parent;
   }
-  
   @Override
   public boolean canSetInModel() {
     return parent != null && true && true;
   }
-  
   @Override
+  @SuppressWarnings("unchecked")
   public String checkAssignment(Object value) {
     return (String) value;
   }
-  
   @Override
-  public Class getEditedType() {
+  @SuppressWarnings("unchecked")
+  public Class<String> getEditedType() {
     return java.lang.String.class;
   }
-  
   @Override
   public String getFromModel() {
     return (parent != null && true) ? parent.getEmail() : null;
   }
-  
   @Override
   public void setInModel(String data) {
     parent.setEmail(data);

--- a/gwt-editor-processor/src/test/resources/org/gwtproject/editor/processor/test04/result/TestEditor04_firstName_Context.java
+++ b/gwt-editor-processor/src/test/resources/org/gwtproject/editor/processor/test04/result/TestEditor04_firstName_Context.java
@@ -1,41 +1,36 @@
 package org.gwtproject.editor.processor.test04;
-
 import java.lang.Class;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
+import java.lang.SuppressWarnings;
 import org.gwtproject.editor.client.Editor;
 import org.gwtproject.editor.client.impl.AbstractEditorContext;
 import org.gwtproject.editor.processor.common.UserDto;
-
 public class TestEditor04_firstName_Context extends AbstractEditorContext<String> {
   private final UserDto parent;
-  
   public TestEditor04_firstName_Context(UserDto parent, Editor<String> editor, String path) {
     super(editor, path);
     this.parent = parent;
   }
-  
   @Override
   public boolean canSetInModel() {
     return parent != null && true && true;
   }
-  
   @Override
+  @SuppressWarnings("unchecked")
   public String checkAssignment(Object value) {
     return (String) value;
   }
-  
   @Override
-  public Class getEditedType() {
+  @SuppressWarnings("unchecked")
+  public Class<String> getEditedType() {
     return java.lang.String.class;
   }
-  
   @Override
   public String getFromModel() {
     return (parent != null && true) ? parent.getFirstName() : null;
   }
-  
   @Override
   public void setInModel(String data) {
     parent.setFirstName(data);

--- a/gwt-editor-processor/src/test/resources/org/gwtproject/editor/processor/test04/result/TestEditor04_id_Context.java
+++ b/gwt-editor-processor/src/test/resources/org/gwtproject/editor/processor/test04/result/TestEditor04_id_Context.java
@@ -1,42 +1,37 @@
 package org.gwtproject.editor.processor.test04;
-
 import java.lang.Class;
 import java.lang.Long;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
+import java.lang.SuppressWarnings;
 import org.gwtproject.editor.client.Editor;
 import org.gwtproject.editor.client.impl.AbstractEditorContext;
 import org.gwtproject.editor.processor.common.UserDto;
-
 public class TestEditor04_id_Context extends AbstractEditorContext<Long> {
   private final UserDto parent;
-  
   public TestEditor04_id_Context(UserDto parent, Editor<Long> editor, String path) {
     super(editor, path);
     this.parent = parent;
   }
-  
   @Override
   public boolean canSetInModel() {
     return parent != null && true && true;
   }
-  
   @Override
+  @SuppressWarnings("unchecked")
   public Long checkAssignment(Object value) {
     return (Long) value;
   }
-  
   @Override
-  public Class getEditedType() {
+  @SuppressWarnings("unchecked")
+  public Class<Long> getEditedType() {
     return java.lang.Long.class;
   }
-  
   @Override
   public Long getFromModel() {
     return (parent != null && true) ? parent.getId() : null;
   }
-  
   @Override
   public void setInModel(Long data) {
     parent.setId(data);

--- a/gwt-editor-processor/src/test/resources/org/gwtproject/editor/processor/test04/result/TestEditor04_lastName_Context.java
+++ b/gwt-editor-processor/src/test/resources/org/gwtproject/editor/processor/test04/result/TestEditor04_lastName_Context.java
@@ -1,41 +1,36 @@
 package org.gwtproject.editor.processor.test04;
-
 import java.lang.Class;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
+import java.lang.SuppressWarnings;
 import org.gwtproject.editor.client.Editor;
 import org.gwtproject.editor.client.impl.AbstractEditorContext;
 import org.gwtproject.editor.processor.common.UserDto;
-
 public class TestEditor04_lastName_Context extends AbstractEditorContext<String> {
   private final UserDto parent;
-  
   public TestEditor04_lastName_Context(UserDto parent, Editor<String> editor, String path) {
     super(editor, path);
     this.parent = parent;
   }
-  
   @Override
   public boolean canSetInModel() {
     return parent != null && true && true;
   }
-  
   @Override
+  @SuppressWarnings("unchecked")
   public String checkAssignment(Object value) {
     return (String) value;
   }
-  
   @Override
-  public Class getEditedType() {
+  @SuppressWarnings("unchecked")
+  public Class<String> getEditedType() {
     return java.lang.String.class;
   }
-  
   @Override
   public String getFromModel() {
     return (parent != null && true) ? parent.getLastName() : null;
   }
-  
   @Override
   public void setInModel(String data) {
     parent.setLastName(data);

--- a/gwt-editor-processor/src/test/resources/org/gwtproject/editor/processor/test04/result/TestEditor04_phone_Context.java
+++ b/gwt-editor-processor/src/test/resources/org/gwtproject/editor/processor/test04/result/TestEditor04_phone_Context.java
@@ -1,41 +1,36 @@
 package org.gwtproject.editor.processor.test04;
-
 import java.lang.Class;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
+import java.lang.SuppressWarnings;
 import org.gwtproject.editor.client.Editor;
 import org.gwtproject.editor.client.impl.AbstractEditorContext;
 import org.gwtproject.editor.processor.common.UserDto;
-
 public class TestEditor04_phone_Context extends AbstractEditorContext<String> {
   private final UserDto parent;
-  
   public TestEditor04_phone_Context(UserDto parent, Editor<String> editor, String path) {
     super(editor, path);
     this.parent = parent;
   }
-  
   @Override
   public boolean canSetInModel() {
     return parent != null && true && true;
   }
-  
   @Override
+  @SuppressWarnings("unchecked")
   public String checkAssignment(Object value) {
     return (String) value;
   }
-  
   @Override
-  public Class getEditedType() {
+  @SuppressWarnings("unchecked")
+  public Class<String> getEditedType() {
     return java.lang.String.class;
   }
-  
   @Override
   public String getFromModel() {
     return (parent != null && true) ? parent.getPhone() : null;
   }
-  
   @Override
   public void setInModel(String data) {
     parent.setPhone(data);

--- a/gwt-editor-processor/src/test/resources/org/gwtproject/editor/processor/test05/result/TestEditor05_Driver_Impl.java
+++ b/gwt-editor-processor/src/test/resources/org/gwtproject/editor/processor/test05/result/TestEditor05_Driver_Impl.java
@@ -1,6 +1,7 @@
 package org.gwtproject.editor.processor.test05;
 
 import java.lang.Override;
+import java.lang.SuppressWarnings;
 import org.gwtproject.editor.client.EditorVisitor;
 import org.gwtproject.editor.client.impl.AbstractSimpleBeanEditorDriver;
 import org.gwtproject.editor.client.impl.RootEditorContext;
@@ -9,6 +10,7 @@ import org.gwtproject.editor.processor.common.Model01Dto;
 
 public class TestEditor05_Driver_Impl extends AbstractSimpleBeanEditorDriver<Model01Dto, TestEditor05> implements TestEditor05.Driver {
   @Override
+  @SuppressWarnings("unchecked")
   public void accept(EditorVisitor visitor) {
     RootEditorContext<Model01Dto> ctx = new RootEditorContext<Model01Dto>(getDelegate(), (Class<Model01Dto>)(Class)org.gwtproject.editor.processor.common.Model01Dto.class, getObject());
     ctx.traverse(visitor, getDelegate());

--- a/gwt-editor-processor/src/test/resources/org/gwtproject/editor/processor/test05/result/TestEditor05_email_Context.java
+++ b/gwt-editor-processor/src/test/resources/org/gwtproject/editor/processor/test05/result/TestEditor05_email_Context.java
@@ -1,41 +1,36 @@
 package org.gwtproject.editor.processor.test05;
-
 import java.lang.Class;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
+import java.lang.SuppressWarnings;
 import org.gwtproject.editor.client.Editor;
 import org.gwtproject.editor.client.impl.AbstractEditorContext;
 import org.gwtproject.editor.processor.common.Model01Dto;
-
 public class TestEditor05_email_Context extends AbstractEditorContext<String> {
   private final Model01Dto parent;
-  
   public TestEditor05_email_Context(Model01Dto parent, Editor<String> editor, String path) {
     super(editor, path);
     this.parent = parent;
   }
-  
   @Override
   public boolean canSetInModel() {
     return parent != null && true && true;
   }
-  
   @Override
+  @SuppressWarnings("unchecked")
   public String checkAssignment(Object value) {
     return (String) value;
   }
-  
   @Override
-  public Class getEditedType() {
+  @SuppressWarnings("unchecked")
+  public Class<String> getEditedType() {
     return java.lang.String.class;
   }
-  
   @Override
   public String getFromModel() {
     return (parent != null && true) ? parent.getEmail() : null;
   }
-  
   @Override
   public void setInModel(String data) {
     parent.setEmail(data);

--- a/gwt-editor-processor/src/test/resources/org/gwtproject/editor/processor/test05/result/TestEditor05_id_Context.java
+++ b/gwt-editor-processor/src/test/resources/org/gwtproject/editor/processor/test05/result/TestEditor05_id_Context.java
@@ -5,6 +5,7 @@ import java.lang.Long;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
+import java.lang.SuppressWarnings;
 import org.gwtproject.editor.client.Editor;
 import org.gwtproject.editor.client.impl.AbstractEditorContext;
 import org.gwtproject.editor.processor.common.Model01Dto;
@@ -23,12 +24,14 @@ public class TestEditor05_id_Context extends AbstractEditorContext<Long> {
   }
   
   @Override
+  @SuppressWarnings("unchecked")
   public Long checkAssignment(Object value) {
     return (Long) value;
   }
   
   @Override
-  public Class getEditedType() {
+  @SuppressWarnings("unchecked")
+  public Class<Long> getEditedType() {
     return java.lang.Long.class;
   }
   

--- a/gwt-editor-processor/src/test/resources/org/gwtproject/editor/processor/test05/result/TestEditor05_name_Context.java
+++ b/gwt-editor-processor/src/test/resources/org/gwtproject/editor/processor/test05/result/TestEditor05_name_Context.java
@@ -4,6 +4,7 @@ import java.lang.Class;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
+import java.lang.SuppressWarnings;
 import org.gwtproject.editor.client.Editor;
 import org.gwtproject.editor.client.impl.AbstractEditorContext;
 import org.gwtproject.editor.processor.common.Model01Dto;
@@ -22,12 +23,14 @@ public class TestEditor05_name_Context extends AbstractEditorContext<String> {
   }
   
   @Override
+  @SuppressWarnings("unchecked")
   public String checkAssignment(Object value) {
     return (String) value;
   }
   
   @Override
-  public Class getEditedType() {
+  @SuppressWarnings("unchecked")
+  public Class<String> getEditedType() {
     return java.lang.String.class;
   }
   

--- a/gwt-editor-processor/src/test/resources/org/gwtproject/editor/processor/test05/result/TestEditor05_phone_Context.java
+++ b/gwt-editor-processor/src/test/resources/org/gwtproject/editor/processor/test05/result/TestEditor05_phone_Context.java
@@ -4,6 +4,7 @@ import java.lang.Class;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
+import java.lang.SuppressWarnings;
 import org.gwtproject.editor.client.Editor;
 import org.gwtproject.editor.client.impl.AbstractEditorContext;
 import org.gwtproject.editor.processor.common.Model01Dto;
@@ -22,12 +23,14 @@ public class TestEditor05_phone_Context extends AbstractEditorContext<String> {
   }
   
   @Override
+  @SuppressWarnings("unchecked")
   public String checkAssignment(Object value) {
     return (String) value;
   }
   
   @Override
-  public Class getEditedType() {
+  @SuppressWarnings("unchecked")
+  public Class<String> getEditedType() {
     return java.lang.String.class;
   }
   

--- a/gwt-editor-processor/src/test/resources/org/gwtproject/editor/processor/test06/result/TestEditor06_email_Context.java
+++ b/gwt-editor-processor/src/test/resources/org/gwtproject/editor/processor/test06/result/TestEditor06_email_Context.java
@@ -1,41 +1,36 @@
 package org.gwtproject.editor.processor.test06;
-
 import java.lang.Class;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
+import java.lang.SuppressWarnings;
 import org.gwtproject.editor.client.Editor;
 import org.gwtproject.editor.client.impl.AbstractEditorContext;
 import org.gwtproject.editor.processor.common.BadModel01Dto;
-
 public class TestEditor06_email_Context extends AbstractEditorContext<String> {
   private final BadModel01Dto parent;
-  
   public TestEditor06_email_Context(BadModel01Dto parent, Editor<String> editor, String path) {
     super(editor, path);
     this.parent = parent;
   }
-  
   @Override
   public boolean canSetInModel() {
     return parent != null && false && true;
   }
-  
   @Override
+  @SuppressWarnings("unchecked")
   public String checkAssignment(Object value) {
     return (String) value;
   }
-  
   @Override
-  public Class getEditedType() {
+  @SuppressWarnings("unchecked")
+  public Class<String> getEditedType() {
     return java.lang.String.class;
   }
-  
   @Override
   public String getFromModel() {
     return (parent != null && true) ? parent.getEmail() : null;
   }
-  
   @Override
   public void setInModel(String data) {
     throw new UnsupportedOperationException();

--- a/gwt-editor-processor/src/test/resources/org/gwtproject/editor/processor/test07/result/TestEditor07_Driver_Impl.java
+++ b/gwt-editor-processor/src/test/resources/org/gwtproject/editor/processor/test07/result/TestEditor07_Driver_Impl.java
@@ -1,20 +1,19 @@
 package org.gwtproject.editor.processor.test07;
-
 import java.lang.Override;
 import java.lang.String;
+import java.lang.SuppressWarnings;
 import org.gwtproject.editor.client.EditorVisitor;
 import org.gwtproject.editor.client.impl.AbstractSimpleBeanEditorDriver;
 import org.gwtproject.editor.client.impl.RootEditorContext;
 import org.gwtproject.editor.client.impl.SimpleBeanEditorDelegate;
 import org.gwtproject.editor.processor.common.Model01Generic02Dto;
-
 public class TestEditor07_Driver_Impl extends AbstractSimpleBeanEditorDriver<Model01Generic02Dto<String>, TestEditor07> implements TestEditor07.Driver {
   @Override
+  @SuppressWarnings("unchecked")
   public void accept(EditorVisitor visitor) {
     RootEditorContext<Model01Generic02Dto<String>> ctx = new RootEditorContext<Model01Generic02Dto<String>>(getDelegate(), (Class<Model01Generic02Dto<String>>)(Class)org.gwtproject.editor.processor.common.Model01Generic02Dto.class, getObject());
     ctx.traverse(visitor, getDelegate());
   }
-  
   @Override
   protected SimpleBeanEditorDelegate<Model01Generic02Dto<String>, TestEditor07> createDelegate() {
     return new TestEditor07_SimpleBeanEditorDelegate();

--- a/gwt-editor-processor/src/test/resources/org/gwtproject/editor/processor/test07/result/TestEditor07_SimpleBeanEditorDelegate.java
+++ b/gwt-editor-processor/src/test/resources/org/gwtproject/editor/processor/test07/result/TestEditor07_SimpleBeanEditorDelegate.java
@@ -1,41 +1,31 @@
 package org.gwtproject.editor.processor.test07;
-import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
-import org.gwtproject.editor.client.Editor;
 import org.gwtproject.editor.client.EditorVisitor;
 import org.gwtproject.editor.client.impl.SimpleBeanEditorDelegate;
 import org.gwtproject.editor.processor.common.Model01Generic02Dto;
-
-public class TestEditor07_SimpleBeanEditorDelegate extends SimpleBeanEditorDelegate {
-
+public class TestEditor07_SimpleBeanEditorDelegate extends SimpleBeanEditorDelegate<Model01Generic02Dto<String>, TestEditor07> {
   private TestEditor07 editor;
   private Model01Generic02Dto<String> object;
-
   @Override
   protected TestEditor07 getEditor() {
     return editor;
   }
-
   @Override
-  protected void setEditor(Editor editor) {
-    this.editor = (TestEditor07) editor;
+  protected void setEditor(TestEditor07 editor) {
+    this.editor = editor;
   }
-
   @Override
   public Model01Generic02Dto<String> getObject() {
     return object;
   }
-
   @Override
-  protected void setObject(Object object) {
-    this.object = (Model01Generic02Dto<String>) object;
+  protected void setObject(Model01Generic02Dto<String> object) {
+    this.object = object;
   }
-
   @Override
   protected void initializeSubDelegates() {
   }
-
   @Override
   public void accept(EditorVisitor visitor) {
     {

--- a/gwt-editor-processor/src/test/resources/org/gwtproject/editor/processor/test07/result/TestEditor07_email_Context.java
+++ b/gwt-editor-processor/src/test/resources/org/gwtproject/editor/processor/test07/result/TestEditor07_email_Context.java
@@ -1,42 +1,37 @@
 package org.gwtproject.editor.processor.test07;
-
 import java.lang.Class;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
+import java.lang.SuppressWarnings;
 import org.gwtproject.editor.client.Editor;
 import org.gwtproject.editor.client.impl.AbstractEditorContext;
 import org.gwtproject.editor.processor.common.Model01Generic02Dto;
-
 public class TestEditor07_email_Context extends AbstractEditorContext<String> {
   private final Model01Generic02Dto<String> parent;
-  
   public TestEditor07_email_Context(Model01Generic02Dto<String> parent, Editor<String> editor,
                                     String path) {
     super(editor, path);
     this.parent = parent;
   }
-  
   @Override
   public boolean canSetInModel() {
     return parent != null && true && true;
   }
-  
   @Override
+  @SuppressWarnings("unchecked")
   public String checkAssignment(Object value) {
     return (String) value;
   }
-  
   @Override
-  public Class getEditedType() {
+  @SuppressWarnings("unchecked")
+  public Class<String> getEditedType() {
     return java.lang.String.class;
   }
-  
   @Override
   public String getFromModel() {
     return (parent != null && true) ? parent.getEmail() : null;
   }
-  
   @Override
   public void setInModel(String data) {
     parent.setEmail(data);

--- a/gwt-editor-processor/src/test/resources/org/gwtproject/editor/processor/test07/result/TestEditor07_id_Context.java
+++ b/gwt-editor-processor/src/test/resources/org/gwtproject/editor/processor/test07/result/TestEditor07_id_Context.java
@@ -5,6 +5,7 @@ import java.lang.Long;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
+import java.lang.SuppressWarnings;
 import org.gwtproject.editor.client.Editor;
 import org.gwtproject.editor.client.impl.AbstractEditorContext;
 import org.gwtproject.editor.processor.common.Model01Generic02Dto;
@@ -23,12 +24,14 @@ public class TestEditor07_id_Context extends AbstractEditorContext<Long> {
   }
   
   @Override()
+  @SuppressWarnings("unchecked")
   public Long checkAssignment(Object value) {
     return (Long)value;
   }
   
   @Override()
-  public Class getEditedType() {
+  @SuppressWarnings("unchecked")
+  public Class<Long> getEditedType() {
     return java.lang.Long.class;
   }
   

--- a/gwt-editor-processor/src/test/resources/org/gwtproject/editor/processor/test07/result/TestEditor07_name_Context.java
+++ b/gwt-editor-processor/src/test/resources/org/gwtproject/editor/processor/test07/result/TestEditor07_name_Context.java
@@ -1,42 +1,37 @@
 package org.gwtproject.editor.processor.test07;
-
 import java.lang.Class;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
+import java.lang.SuppressWarnings;
 import org.gwtproject.editor.client.Editor;
 import org.gwtproject.editor.client.impl.AbstractEditorContext;
 import org.gwtproject.editor.processor.common.Model01Generic02Dto;
-
 public class TestEditor07_name_Context extends AbstractEditorContext<String> {
   private final Model01Generic02Dto<String> parent;
-  
   public TestEditor07_name_Context(Model01Generic02Dto<String> parent, Editor<String> editor,
-                                    String path) {
+                                   String path) {
     super(editor, path);
     this.parent = parent;
   }
-  
   @Override
   public boolean canSetInModel() {
     return parent != null && true && true;
   }
-  
   @Override
+  @SuppressWarnings("unchecked")
   public String checkAssignment(Object value) {
     return (String) value;
   }
-  
   @Override
-  public Class getEditedType() {
+  @SuppressWarnings("unchecked")
+  public Class<String> getEditedType() {
     return java.lang.String.class;
   }
-  
   @Override
   public String getFromModel() {
     return (parent != null && true) ? parent.getName() : null;
   }
-  
   @Override
   public void setInModel(String data) {
     parent.setName(data);

--- a/gwt-editor-processor/src/test/resources/org/gwtproject/editor/processor/test07/result/TestEditor07_phone_Context.java
+++ b/gwt-editor-processor/src/test/resources/org/gwtproject/editor/processor/test07/result/TestEditor07_phone_Context.java
@@ -4,6 +4,7 @@ import java.lang.Class;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
+import java.lang.SuppressWarnings;
 import org.gwtproject.editor.client.Editor;
 import org.gwtproject.editor.client.impl.AbstractEditorContext;
 import org.gwtproject.editor.processor.common.Model01Generic02Dto;
@@ -23,12 +24,14 @@ public class TestEditor07_phone_Context extends AbstractEditorContext<String> {
   }
   
   @Override
+  @SuppressWarnings("unchecked")
   public String checkAssignment(Object value) {
     return (String) value;
   }
   
   @Override
-  public Class getEditedType() {
+  @SuppressWarnings("unchecked")
+  public Class<String> getEditedType() {
     return java.lang.String.class;
   }
   

--- a/gwt-editor-processor/src/test/resources/org/gwtproject/editor/processor/test08/result/TestEditor08_Driver_Impl.java
+++ b/gwt-editor-processor/src/test/resources/org/gwtproject/editor/processor/test08/result/TestEditor08_Driver_Impl.java
@@ -1,6 +1,7 @@
 package org.gwtproject.editor.processor.test08;
 
 import java.lang.Override;
+import java.lang.SuppressWarnings;
 import org.gwtproject.editor.client.EditorVisitor;
 import org.gwtproject.editor.client.impl.AbstractSimpleBeanEditorDriver;
 import org.gwtproject.editor.client.impl.RootEditorContext;
@@ -9,6 +10,7 @@ import org.gwtproject.editor.processor.common.Model01Dto;
 
 public class TestEditor08_Driver_Impl extends AbstractSimpleBeanEditorDriver<Model01Dto, TestEditor08> implements TestEditor08.Driver {
   @Override
+  @SuppressWarnings("unchecked")
   public void accept(EditorVisitor visitor) {
     RootEditorContext<Model01Dto> ctx = new RootEditorContext<Model01Dto>(getDelegate(), (Class<Model01Dto>)(Class)org.gwtproject.editor.processor.common.Model01Dto.class, getObject());
     ctx.traverse(visitor, getDelegate());

--- a/gwt-editor-processor/src/test/resources/org/gwtproject/editor/processor/test08/result/TestEditor08_SimpleBeanEditorDelegate.java
+++ b/gwt-editor-processor/src/test/resources/org/gwtproject/editor/processor/test08/result/TestEditor08_SimpleBeanEditorDelegate.java
@@ -1,34 +1,35 @@
 package org.gwtproject.editor.processor.test08;
-import java.lang.Object;
+import java.lang.Long;
 import java.lang.Override;
-import org.gwtproject.editor.client.Editor;
+import java.lang.String;
 import org.gwtproject.editor.client.EditorVisitor;
 import org.gwtproject.editor.client.impl.SimpleBeanEditorDelegate;
+import org.gwtproject.editor.client.testing.FakeLeafValueEditorWithHasEditorDelegate;
 import org.gwtproject.editor.client.testing.FakeLeafValueEditorWithHasEditorDelegate_Long_SimpleBeanEditorDelegate;
 import org.gwtproject.editor.client.testing.FakeLeafValueEditorWithHasEditorDelegate_String_SimpleBeanEditorDelegate;
 import org.gwtproject.editor.processor.common.Model01Dto;
-public class TestEditor08_SimpleBeanEditorDelegate extends SimpleBeanEditorDelegate {
+public class TestEditor08_SimpleBeanEditorDelegate extends SimpleBeanEditorDelegate<Model01Dto, TestEditor08> {
   private TestEditor08 editor;
   private Model01Dto object;
-  private SimpleBeanEditorDelegate idDelegate;
-  private SimpleBeanEditorDelegate nameDelegate;
-  private SimpleBeanEditorDelegate phoneDelegate;
-  private SimpleBeanEditorDelegate emailDelegate;
+  private SimpleBeanEditorDelegate<Long, FakeLeafValueEditorWithHasEditorDelegate<Long>> idDelegate;
+  private SimpleBeanEditorDelegate<String, FakeLeafValueEditorWithHasEditorDelegate<String>> nameDelegate;
+  private SimpleBeanEditorDelegate<String, FakeLeafValueEditorWithHasEditorDelegate<String>> phoneDelegate;
+  private SimpleBeanEditorDelegate<String, FakeLeafValueEditorWithHasEditorDelegate<String>> emailDelegate;
   @Override
   protected TestEditor08 getEditor() {
     return editor;
   }
   @Override
-  protected void setEditor(Editor editor) {
-    this.editor = (TestEditor08) editor;
+  protected void setEditor(TestEditor08 editor) {
+    this.editor = editor;
   }
   @Override
   public Model01Dto getObject() {
     return object;
   }
   @Override
-  protected void setObject(Object object) {
-    this.object = (Model01Dto) object;
+  protected void setObject(Model01Dto object) {
+    this.object = object;
   }
   @Override
   protected void initializeSubDelegates() {
@@ -72,4 +73,3 @@ public class TestEditor08_SimpleBeanEditorDelegate extends SimpleBeanEditorDeleg
       ctx.traverse(visitor, emailDelegate);
     }
   }
-}

--- a/gwt-editor-processor/src/test/resources/org/gwtproject/editor/processor/test08/result/TestEditor08_email_Context.java
+++ b/gwt-editor-processor/src/test/resources/org/gwtproject/editor/processor/test08/result/TestEditor08_email_Context.java
@@ -1,41 +1,36 @@
 package org.gwtproject.editor.processor.test08;
-
 import java.lang.Class;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
+import java.lang.SuppressWarnings;
 import org.gwtproject.editor.client.Editor;
 import org.gwtproject.editor.client.impl.AbstractEditorContext;
 import org.gwtproject.editor.processor.common.Model01Dto;
-
 public class TestEditor08_email_Context extends AbstractEditorContext<String> {
   private final Model01Dto parent;
-  
   public TestEditor08_email_Context(Model01Dto parent, Editor<String> editor, String path) {
     super(editor, path);
     this.parent = parent;
   }
-  
   @Override
   public boolean canSetInModel() {
     return parent != null && true && true;
   }
-  
   @Override
+  @SuppressWarnings("unchecked")
   public String checkAssignment(Object value) {
     return (String) value;
   }
-  
   @Override
-  public Class getEditedType() {
+  @SuppressWarnings("unchecked")
+  public Class<String> getEditedType() {
     return java.lang.String.class;
   }
-  
   @Override
   public String getFromModel() {
     return (parent != null && true) ? parent.getEmail() : null;
   }
-  
   @Override
   public void setInModel(String data) {
     parent.setEmail(data);

--- a/gwt-editor-processor/src/test/resources/org/gwtproject/editor/processor/test08/result/TestEditor08_id_Context.java
+++ b/gwt-editor-processor/src/test/resources/org/gwtproject/editor/processor/test08/result/TestEditor08_id_Context.java
@@ -5,6 +5,7 @@ import java.lang.Long;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
+import java.lang.SuppressWarnings;
 import org.gwtproject.editor.client.Editor;
 import org.gwtproject.editor.client.impl.AbstractEditorContext;
 import org.gwtproject.editor.processor.common.Model01Dto;
@@ -23,12 +24,14 @@ public class TestEditor08_id_Context extends AbstractEditorContext<Long> {
   }
   
   @Override
+  @SuppressWarnings("unchecked")
   public Long checkAssignment(Object value) {
     return (Long) value;
   }
   
   @Override
-  public Class getEditedType() {
+  @SuppressWarnings("unchecked")
+  public Class<Long> getEditedType() {
     return java.lang.Long.class;
   }
   

--- a/gwt-editor-processor/src/test/resources/org/gwtproject/editor/processor/test08/result/TestEditor08_name_Context.java
+++ b/gwt-editor-processor/src/test/resources/org/gwtproject/editor/processor/test08/result/TestEditor08_name_Context.java
@@ -4,6 +4,7 @@ import java.lang.Class;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
+import java.lang.SuppressWarnings;
 import org.gwtproject.editor.client.Editor;
 import org.gwtproject.editor.client.impl.AbstractEditorContext;
 import org.gwtproject.editor.processor.common.Model01Dto;
@@ -22,12 +23,14 @@ public class TestEditor08_name_Context extends AbstractEditorContext<String> {
   }
   
   @Override
+  @SuppressWarnings("unchecked")
   public String checkAssignment(Object value) {
     return (String) value;
   }
   
   @Override
-  public Class getEditedType() {
+  @SuppressWarnings("unchecked")
+  public Class<String> getEditedType() {
     return java.lang.String.class;
   }
   

--- a/gwt-editor-processor/src/test/resources/org/gwtproject/editor/processor/test08/result/TestEditor08_phone_Context.java
+++ b/gwt-editor-processor/src/test/resources/org/gwtproject/editor/processor/test08/result/TestEditor08_phone_Context.java
@@ -4,6 +4,7 @@ import java.lang.Class;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
+import java.lang.SuppressWarnings;
 import org.gwtproject.editor.client.Editor;
 import org.gwtproject.editor.client.impl.AbstractEditorContext;
 import org.gwtproject.editor.processor.common.Model01Dto;
@@ -22,12 +23,14 @@ public class TestEditor08_phone_Context extends AbstractEditorContext<String> {
   }
   
   @Override
+  @SuppressWarnings("unchecked")
   public String checkAssignment(Object value) {
     return (String) value;
   }
   
   @Override
-  public Class getEditedType() {
+  @SuppressWarnings("unchecked")
+  public Class<String> getEditedType() {
     return java.lang.String.class;
   }
   

--- a/gwt-editor/pom.xml
+++ b/gwt-editor/pom.xml
@@ -47,7 +47,7 @@
   <inceptionYear>2018</inceptionYear>
 
   <properties>
-    <maven.gwt.plugin>1.0.0</maven.gwt.plugin>
+    <maven.gwt.plugin>1.1.0</maven.gwt.plugin>
 
     <gwt-event.version>1.0.0-RC1</gwt-event.version>
   </properties>

--- a/gwt-editor/src/main/java/org/gwtproject/editor/client/impl/Initializer.java
+++ b/gwt-editor/src/main/java/org/gwtproject/editor/client/impl/Initializer.java
@@ -24,12 +24,10 @@ import org.gwtproject.editor.client.HasEditorDelegate;
  * Extends the logic in Refresher to provide the editor instance with references to framework
  * plumbing fixes.
  */
-@SuppressWarnings("rawtypes")
 public class Initializer extends Refresher {
 
   @Override
   public <Q> boolean visit(EditorContext<Q> ctx) {
-    @SuppressWarnings("unchecked")
     AbstractEditorDelegate<Q, ?> delegate = (AbstractEditorDelegate<Q, ?>) ctx.getEditorDelegate();
 
     // Pass in the EditorDelegate
@@ -42,7 +40,6 @@ public class Initializer extends Refresher {
     CompositeEditor<Q, ?, ?> asComposite = ctx.asCompositeEditor();
     if (asComposite != null) {
       // Various javac generics compilation problems here
-      @SuppressWarnings("rawtypes")
       EditorChain chain = delegate.getEditorChain();
       asComposite.setEditorChain(chain);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <maven.license.plugin>3.0</maven.license.plugin>
         <maven.shade.version>3.2.4</maven.shade.version>
         <maven.source.plugin>3.2.1</maven.source.plugin>
-        <plugin.version.surfire>3.2.3</plugin.version.surfire>
+        <maven.surfire.plugin>3.2.3</maven.surfire.plugin>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -54,8 +54,8 @@
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
 
         <maven.compiler.plugin>3.8.1</maven.compiler.plugin>
         <maven.deploy.plugin>3.0.0-M1</maven.deploy.plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -52,8 +52,6 @@
     <properties>
         <revision>HEAD-SNAPSHOT</revision>
 
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
 
@@ -68,6 +66,8 @@
         <maven.shade.version>3.2.4</maven.shade.version>
         <maven.source.plugin>3.2.1</maven.source.plugin>
         <plugin.version.surfire>3.2.3</plugin.version.surfire>
+
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,7 @@
         <maven.shade.version>3.2.4</maven.shade.version>
         <maven.source.plugin>3.2.1</maven.source.plugin>
         <maven.surfire.plugin>3.2.3</maven.surfire.plugin>
+        <maven.versions.plugin>2.18.0</maven.versions.plugin>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
@@ -182,6 +183,39 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+
+    <reporting>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>versions-maven-plugin</artifactId>
+                <version>${maven.versions.plugin}</version>
+                <configuration>
+                    <ruleSet>
+                        <ignoreVersions>
+                            <igonreVersion>
+                                <type>regex</type>
+                                <version>(.+-M\d)</version>
+                            </igonreVersion>
+                            <igonreVersion>
+                                <type>regex</type>
+                                <version>.+-(alpha|beta).+</version>
+                            </igonreVersion>
+                        </ignoreVersions>
+                    </ruleSet>
+                </configuration>
+                <reportSets>
+                    <reportSet>
+                        <reports>
+                            <report>dependency-updates-report</report>
+                            <report>plugin-updates-report</report>
+                            <report>property-updates-report</report>
+                        </reports>
+                    </reportSet>
+                </reportSets>
+            </plugin>
+        </plugins>
+    </reporting>
 
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
 
-        <maven.compiler.plugin>3.8.1</maven.compiler.plugin>
+        <maven.compiler.plugin>3.14.0</maven.compiler.plugin>
         <maven.deploy.plugin>3.0.0-M1</maven.deploy.plugin>
         <maven.flatten.plugin>1.2.2</maven.flatten.plugin>
         <maven.fmt.plugin>2.9</maven.fmt.plugin>
@@ -67,7 +67,7 @@
         <maven.license.plugin>3.0</maven.license.plugin>
         <maven.shade.version>3.2.4</maven.shade.version>
         <maven.source.plugin>3.2.1</maven.source.plugin>
-        <maven.surfire.plugin>3.0.0-M1</maven.surfire.plugin>
+        <plugin.version.surfire>3.2.3</plugin.version.surfire>
     </properties>
 
     <build>


### PR DESCRIPTION
This PR will remove the warnings mentioned in issue #11. 

Were able to remove most of the warnings. A few aren't able to remove (the cast stuff). There a @SuppressWarnings("unchecked") is added.

All tests are ok, tested the HEAD-SNAPSHOT locally. Looks good to me. 